### PR TITLE
Handle the case where the http request errors and there is no response

### DIFF
--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -268,8 +268,8 @@ Client.prototype.statementResource = function(opts) {
         return;
       }
       client.request(next_uri, function(error, code, response){
-        if (response.error) {
-          error_callback(response.error);
+        if (error || response.error) {
+          error_callback(error || response.error);
           return;
         }
 


### PR DESCRIPTION
I know this is old code but there's a minor bug. If the http request fails then only an error is sent to the callback here: https://github.com/snoble/presto-client-node/blob/master/lib/presto-client/index.js#L69, which leads to attempting to call `error` on `undefined`.