### PR TITLE
Time zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Execute query on Presto cluster, and fetch results.
      * schema string (default: intance default schema)
    * session [string]
      * set session variables via the [X-Presto-Session header](https://stackoverflow.com/questions/37082016/how-to-manage-presto-query-session-variables-using-rest-api) - string should have form `key1=val1,key2=val2` 
+   * timezone [string :optional]
+     * set time zone via [X-Presto-Time-Zone header](https://prestodb.io/docs/current/release/release-0.66.html)
 * callback [function(error, data, columns)]
  * called once when query finished
  * data
@@ -98,6 +100,7 @@ Attributes of opts [object] are:
 * query [string]
 * catalog [string]
 * schema [string]
+* timezone [string :optional]
 * info [boolean :optional]
   * fetch query info (execution statistics) for success callback, or not (default false)
 * cancel [function() :optional]

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ var client = new presto.Client({
 
 ## Versions
 
+* 0.1.3:
+  * add X-Presto-Time-Zone if "timezone" specified
 * 0.1.2:
   * add X-Presto-Session if "session" specified
 * 0.1.1:

--- a/lib/presto-client/headers.js
+++ b/lib/presto-client/headers.js
@@ -7,6 +7,8 @@ Headers.SOURCE = 'X-Presto-Source';
 Headers.CATALOG = 'X-Presto-Catalog';
 Headers.SCHEMA = 'X-Presto-Schema';
 
+Headers.TIME_ZONE = 'X-Presto-Time-Zone';
+
 Headers.CURRENT_STATE = 'X-Presto-Current-State';
 Headers.MAX_WAIT = 'X-Presto-Max-Wait';
 Headers.MAX_SIZE = 'X-Presto-Max-Size';

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -143,6 +143,8 @@ Client.prototype.executeResource = function(opts, callback) {
 
   if (opts.session)
     header[Headers.SESSION] = opts.session;
+  if (opts.timezone)
+    header[Headers.TIME_ZONE] = opts.timezone;
 
   var req = { method: 'POST', path: '/v1/execute', headers: header, body: query };
   client.request(req, function(err, code, content){
@@ -173,6 +175,9 @@ Client.prototype.statementResource = function(opts) {
 
   if (opts.session)
     header[Headers.SESSION] = opts.session;
+  if (opts.timezone)
+    header[Headers.TIME_ZONE] = opts.timezone;
+
 
   var fetch_info = opts.info || false;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "presto-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Distributed query engine Presto client library for node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fix for https://github.com/tagomoris/presto-client-node/issues/6

I decided to keep `opts.timezone` optional in `execute()` for now, in order to keep backward compatibility.

Example code:
```
var presto = require('presto-client');
var client = new presto.Client({ catalog: 'cassandra', schema: 'test' });

client.execute({ query: 'show tables', timezone:'UTC' }, function(error, data, columns) {
  if (error) return console.log(error);
  console.log(data);
});
```