### PR TITLE
Add a feature for basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Instanciate client object and set default configurations.
     * presto coordinator port (default: 8080)
   * user [string]
     * username of query (default: process user name)
+  * basic_auth [object]
+    * Pass in a user and password to enable Authorization Basic headers on all requests.
+    * basic_auth: {user: "user", password: "password"} (default:null)
   * catalog [string]
     * default catalog name
   * schema [string]

--- a/lib/presto-client/headers.js
+++ b/lib/presto-client/headers.js
@@ -17,3 +17,5 @@ Headers.PAGE_SEQUENCE_ID = 'X-Presto-Page-Sequence-Id';
 Headers.SESSION = 'X-Presto-Session';
 
 Headers.USER_AGENT = 'User-Agent';
+
+Headers.AUTHORIZATION = 'Authorization';

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -1,3 +1,5 @@
+var parseUrl = require('parse-url');
+
 var adapterFor = (function() {
     adapters = {
       'http:': require('http'),
@@ -24,6 +26,7 @@ var Client = exports.Client = function(args){
   this.host = args.host || 'localhost';
   this.port = args.port || 8080;
   this.user = args.user || process.env.USER;
+  this.basic_auth = args.basic_auth || null;
   this.protocol = 'http:';
 
   this.catalog = args.catalog;
@@ -58,10 +61,42 @@ Client.prototype.request = function(opts, callback) {
 
     opts.headers[Headers.USER_AGENT] = this.userAgent;
 
+    /**
+     * Apply an Authorization header if the user
+     * has specified a client.basic_auth object.
+     * client.basic_auth = { user: "<user", password : "<password>"}
+     */
+    if (client.basic_auth)
+      opts.headers[Headers.AUTHORIZATION] = 'Basic ' + new Buffer(client.basic_auth.user + ":" + client.basic_auth.password).toString("base64");
+
+
     if (opts.body)
       contentBody = opts.body;
 
     opts.agent = new adapter.Agent(opts); // Otherwise SSL params are ignored.
+  } else {
+    /**
+     * The request has not come through as an object,
+     * it is a nextUri string. Hence, if basic auth is to be applied
+     * to the request, we must parse the
+     * incoming string (opts) and form a new request object with
+     * appropriate basic auth headers
+     */
+    if (client.basic_auth){
+      var href = parseUrl(opts);
+      opts = {}
+      opts.host = href.resource
+      opts.port = href.port
+      opts.protocol = client.protocol;
+      opts.path = href.pathname;
+      opts.headers = {};
+      opts.headers[Headers.AUTHORIZATION] = 'Basic ' + new Buffer(client.basic_auth.user + ":" + client.basic_auth.password).toString("base64");
+    }
+    /**
+     * Otherwise, if basic auth not required, continue
+     * with request as normal leaving the opts string
+     * unmodified for the below adapter.request() call
+     */
   }
 
   var parser = this.jsonParser;

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -1,4 +1,4 @@
-var parseUrl = require('parse-url');
+const { URL } = require('url') ;
 
 var adapterFor = (function() {
     adapters = {
@@ -83,10 +83,10 @@ Client.prototype.request = function(opts, callback) {
      * appropriate basic auth headers
      */
     if (client.basic_auth){
-      var href = parseUrl(opts);
-      opts = {}
-      opts.host = href.resource
-      opts.port = href.port
+      var href = new URL(opts);
+      opts = {};
+      opts.host = href.hostname;
+      opts.port = href.port;
       opts.protocol = client.protocol;
       opts.path = href.pathname;
       opts.headers = {};

--- a/package.json
+++ b/package.json
@@ -17,8 +17,5 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tagomoris/presto-client-node/issues"
-  },
-  "dependencies": {
-    "parse-url": "3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tagomoris/presto-client-node/issues"
+  },
+  "dependencies": {
+    "parse-url": "3.0.2"
   }
 }


### PR DESCRIPTION
This PR is with regards to this topic:
[Issue 18](https://github.com/tagomoris/presto-client-node/issues/18)
1. Added extra header to headers.js - Authorization header
2. Added basic_auth option to the Client function
3. Added functionality within the request function to add Authorization Basic Headers to both an object opt request and a string opt request
4. Added package.json module dependency - parseUrl - such that the nextUri string can be parsed into its separate components and placed into an object prior to a request being fired off
5. Added README.md mention to basic_auth option