### PR TITLE
Feature - enable verbose state flag to see progress of long running queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Instanciate client object and set default configurations.
     * default schema name
   * checkInterval [integer]
     * interval milliseconds of each RPC to check query status (default: 800ms)
+  * enable_verbose_state_callback [boolean]
+    * when set to `true`, this flag modifies the condition of the state change callback to return data every `checkInterval` (default: 800ms). 
+    * when set to `true`, if you wish to modify the frequency of updates you must change the `checkInterval` value accordingly.
+    * when enable_verbose_state_callback is set to `false`, the state change callback will only be called upon a change in state. 
+    * The purpose of this variable is to enable verbose update capability in state callbacks. This is such that "percentage complete" and "processed rows" may be extracted despite the state still remaining in a particular state eg. "RUNNING". 
+    * (default: false)
   * jsonParser [object]
     * custom json parser if required (default: `JSON`)
 

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -33,7 +33,7 @@ var Client = exports.Client = function(args){
   this.schema = args.schema;
 
   this.checkInterval = args.checkInterval || QUERY_STATE_CHECK_INTERVAL;
-
+  
   this.jsonParser = args.jsonParser || JSON;
 
   if (args.ssl) {
@@ -242,7 +242,7 @@ Client.prototype.statementResource = function(opts) {
   var data_callback = opts.data;
   var success_callback = opts.success || opts.callback;
   var error_callback = opts.error || opts.callback;
-  var verbose_state_info = opts.verbose_state_info || false;
+  var enable_verbose_state_callback = opts.enable_verbose_state_callback || false;
 
   var req = { method: 'POST', path: '/v1/statement', headers: header, body: opts.query };
   client.request(req, function(err, code, data){
@@ -340,8 +340,7 @@ Client.prototype.statementResource = function(opts) {
           return;
         }
 
-        if ((state_callback && last_state !== response.stats.state) 
-              || (state_callback && verbose_state_info)) {
+        if (state_callback && (last_state !== response.stats.state || enable_verbose_state_callback)) {
           state_callback(null, response.id, response.stats);
           last_state = response.stats.state;
         }

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -242,6 +242,7 @@ Client.prototype.statementResource = function(opts) {
   var data_callback = opts.data;
   var success_callback = opts.success || opts.callback;
   var error_callback = opts.error || opts.callback;
+  var verbose_state_info = opts.verbose_state_info || false;
 
   var req = { method: 'POST', path: '/v1/statement', headers: header, body: opts.query };
   client.request(req, function(err, code, data){
@@ -339,7 +340,8 @@ Client.prototype.statementResource = function(opts) {
           return;
         }
 
-        if (state_callback && last_state !== response.stats.state) {
+        if ((state_callback && last_state !== response.stats.state) 
+              || (state_callback && verbose_state_info)) {
           state_callback(null, response.id, response.stats);
           last_state = response.stats.state;
         }


### PR DESCRIPTION
**Context of this PR**
A state_callback function is called (if the user specified one) every time the **state** changes as a result of a statementResource call. Statistics are made available in the case that the state has changed. 

eg.
```
           | State: RUNNING
           | Scheduled: false
           | Processed Rows: 0

           | Percentage Complete: 100
           | State: FINISHED
           | Scheduled: true
           | Processed Rows: 1252725777
```
Now, imagine a long running query that remains in a **running state** for **minutes**. The statistics of will be passed back to this library on every nextUri, **however won't be passed back into the state_callback** (unless something similar to my pull request is implemented).

Providing verbose statistics is now possible if this pull request is approved. 

A user may specify a flag `verbose_state_info : true` such that they may make use of all stats that are passed back by presto upon every nextUri call.

Below is an example of console logging percentage complete (if exists) and otherwise showing clear updates to the user that a query is working and not giving them a long wait time with no updates
```
State: PLANNING
Scheduled: false
Processed Rows: 0

Percentage Complete: 22.67536704730832
State: RUNNING
Scheduled: true
Processed Rows: 440048

Percentage Complete: 43.882544861337685
State: RUNNING
Scheduled: true
Processed Rows: 4308868

Percentage Complete: 52.36541598694943
State: RUNNING
Scheduled: true
Processed Rows: 7311218

Percentage Complete: 100
State: FINISHED
Scheduled: true
Processed Rows: 11752324
```

Notice that despite the state not changing (eg. RUNNING x3), we still are able to obtain the statistics that accompany our state, due to setting this new flag. 

Would like to get your thoughts and recommendations if you prefer a different implementation @tagomoris 