### PR TITLE
Remove Client.prototype.executeResource using /v1/execute api

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,6 @@ Distributed query engine "Presto" 's client library for node.js.
 
 ```js
 var presto = require('presto-client');
-var client = new presto.Client({user: 'myname', catalog: 'hive', schema: 'default'});
-
-client.execute('show schemas', function(error, data, columns){
-  console.log({databases: data});
-});
-```
-
-For queries with long process time and heavy output:
-```js
-var presto = require('presto-client');
 var client = new presto.Client({user: 'myname'});
 
 client.execute({
@@ -79,39 +69,9 @@ Instanciate client object and set default configurations.
 
 return value: client instance object
 
-### execute(arg, callback)
-
-If 2nd argument `callback` specified, this api will be selected.
-
-This is an API to execute queries that returns result immediately, like `show schemas`, `show tables` and others. (Using "/v1/execute" HTTP RPC.)
-
-Execute query on Presto cluster, and fetch results.
-
-* arg [Object or string]
- * arg [String]: query string executed
-   * `catalog` and `schema` must be specified in `new Client()` for this argument type
- * arg [Object]
-   * query [string]
-   * catalog [string]
-     * catalog string (default: instance default catalog)
-   * schema [string]
-     * schema string (default: intance default schema)
-   * session [string]
-     * set session variables via the [X-Presto-Session header](https://stackoverflow.com/questions/37082016/how-to-manage-presto-query-session-variables-using-rest-api) - string should have form `key1=val1,key2=val2` 
-   * timezone [string :optional]
-     * set time zone via [X-Presto-Time-Zone header](https://prestodb.io/docs/current/release/release-0.66.html)
-* callback [function(error, data, columns)]
- * called once when query finished
- * data
-   * array of arrays of each field values
-   * `[ [ 'field1Value', 'field2Value', 3 ], [ 'field1Value', 'field2Value', 6 ], ... ]`
- * columns
-   * array of field names and types
-   * `[ { name: 'timestamp', type: 'varchar' }, { name: 'username', type: 'varchar' }, { name: 'cnt', type: 'bigint' } ] `
-
 ### execute(opts)
 
-This is an API to execute queries that really read large amount of data. (Using "/v1/statement" HTTP RPC.)
+This is an API to execute queries. (Using "/v1/statement" HTTP RPC.)
 
 Execute query on Presto cluster, and fetch results.
 
@@ -203,6 +163,8 @@ var client = new presto.Client({
 
 ## Versions
 
+* 0.4.0:
+  * remove support for execute(arg, callback) using `/v1/execute`
 * 0.3.0:
   * add Basic Authentication support
 * 0.2.0:

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -169,48 +169,8 @@ Client.prototype.kill = function(query_id, callback) {
   });
 };
 
-Client.prototype.execute = function(opts, callback) {
-  if (callback)
-    this.executeResource(opts, callback);
-  else
-    this.statementResource(opts);
-};
-
-Client.prototype.executeResource = function(opts, callback) {
-  var client = this;
-
-  var query = null;
-  if (opts instanceof Object) {
-    query = opts.query;
-  } else { // opts is query string itself
-    query = opts;
-    opts = {};
-  }
-
-  if (!opts.catalog && !this.catalog)
-    throw {message: "catalog not specified"};
-  if (!opts.schema && !this.schema)
-    throw {message: "schema not specified"};
-
-  var header = {};
-  header[Headers.CATALOG] = opts.catalog || this.catalog;
-  header[Headers.SCHEMA] = opts.schema || this.schema;
-
-  if (opts.session)
-    header[Headers.SESSION] = opts.session;
-  if (opts.timezone)
-    header[Headers.TIME_ZONE] = opts.timezone;
-
-  var req = { method: 'POST', path: '/v1/execute', headers: header, body: query };
-  client.request(req, function(err, code, content){
-    if (err || code !== 200) {
-      var message = "execution error" + (content && content.length > 0 ? ":" + content : "");
-      callback({message:message, error: err, code: code});
-      return;
-    }
-    // content: {"columns":[{"name":"Schema","type":"varchar"}],"data":[["default"],["information_schema"],["sys"]]}
-    callback(null, content.data, content.columns);
-  });
+Client.prototype.execute = function(opts) {
+  this.statementResource(opts);
 };
 
 Client.prototype.statementResource = function(opts) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "presto-client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Distributed query engine Presto client library for node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fix #14 

Changes: Remove Client.prototype.executeResource using `/v1/execute` api. This commit is no backward compatibility, but I assume it isn't problem since 0.160 is quite old.

Tested below code with presto 307 and it looks fine.
```js
var client = new lib.Client({user: 'ebyhr', catalog: 'hive', schema: 'default'});
client.execute({
    query: 'select 1',
    state:   function(error, query_id, stats){},
    columns: function(error, data){ console.log({resultColumns: data}); },
    data:    function(error, data, columns, stats){ console.log(data); },
    success: function(error, stats){},
    error:   function(error){}
});
```

```sh
$ node test.js
{ resultColumns: [ { name: '_col0', type: 'integer', typeSignature: [Object] } ] }
[ [ 1 ] ]
```