### PR TITLE
add support to prestodb versions 0.226 or above

### DIFF
--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -93,7 +93,7 @@ Client.prototype.request = function(opts, callback) {
       opts.host = href.hostname;
       opts.port = href.port;
       opts.protocol = client.protocol;
-      opts.path = href.pathname;
+      opts.path = href.pathname + href.search;
       opts.headers = {};
       opts.headers[Headers.AUTHORIZATION] = 'Basic ' + new Buffer(client.basic_auth.user + ":" + client.basic_auth.password).toString("base64");
     }


### PR DESCRIPTION
This change is required because since prestodb version 0.226 the nextUri
contains a slug in the query params field of the URI and without it the
API returns a 404 response.

The commit which changed the presto server API: https://github.com/prestodb/presto/commit/67efdcf1330c45a361c58f1c4659aa0fb390951e