### PR TITLE
Support default port for nextUri

### DIFF
--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -60,7 +60,7 @@ Client.prototype.request = function(opts, callback) {
         opts = {
             method: 'GET',
             host: href.hostname,
-            port: href.port,
+            port: href.port || (href.protocol === 'https:' ? 443 : 80),
             path: href.pathname + href.search,
             headers: {},
         };

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -60,7 +60,7 @@ Client.prototype.request = function(opts, callback) {
         opts = {
             method: 'GET',
             host: href.hostname,
-            port: href.port || (href.protocol === 'https:' ? 443 : 80),
+            port: href.port || (href.protocol === 'https:' ? '443' : '80'),
             path: href.pathname + href.search,
             headers: {},
         };


### PR DESCRIPTION
When the `nextUri` doesn't contain an explicit port, `href.port` is an empty string. Ultimately, it will fail in node's underlying check to ensure that it is a valid port.

This PR adds support for default ports when the nextUri is something like this:

`https://presto.mycompany.com/v1/statement/queued/20200722_041411_00666_zd1yb/yca3b19384759874508288e6afc89f627d59d1c1/2`

It uses the default port of `443` for `https:` and assumes `http:` and thus port `80` for anything else.