### PR TITLE
Make catalog and schema optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ client.execute({
 npm install -g presto-client
 ```
 
-Or add `presto-client` to your own `packagen.json`, and do `npm install`.
+Or add `presto-client` to your own `package.json`, and do `npm install`.
 
 ## API
 

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -168,16 +168,19 @@ Client.prototype.statementResource = function(opts) {
     var client = this;
     var columns = null;
 
-    if (!opts.catalog && !this.catalog)
-        throw {message: "catalog not specified"};
-    if (!opts.schema && !this.schema)
-        throw {message: "schema not specified"};
+    if ((opts.schema || this.schema) && !(opts.catalog || this.catalog)) {
+        throw {message: "Catalog not specified; catalog is required if schema is specified"}
+    }
     if (!opts.success && !opts.callback)
         throw {message: "callback function 'success' (or 'callback') not specified"};
 
     var header = {};
-    header[Headers.CATALOG] = opts.catalog || this.catalog;
-    header[Headers.SCHEMA] = opts.schema || this.schema;
+    if (opts.catalog || this.catalog) {
+        header[Headers.CATALOG] = opts.catalog || this.catalog;
+    }
+    if (opts.schema || this.schema) {
+        header[Headers.SCHEMA] = opts.schema || this.schema;
+    }
 
     if (opts.session)
         header[Headers.SESSION] = opts.session;


### PR DESCRIPTION
Catalog and schema are optional header parameters, and throwing when they're not present isn't technically correct.

If catalog and schema aren't specified, then statements must specify the schema and catalog before the table name. For example `select * from tableName` becomes `select * from catalog.schema.tableName`.

Note: Thanks for this client btw! I'm using it to add a Presto adapter to [Dataform](https://github.com/dataform-co/dataform).