### PR TITLE
Rely on client configuration for default port

### DIFF
--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -60,7 +60,7 @@ Client.prototype.request = function(opts, callback) {
         opts = {
             method: 'GET',
             host: href.hostname,
-            port: href.port || (href.protocol === 'https:' ? '443' : '80'),
+            port: href.port || (client.ssl ? '443' : '80'),
             path: href.pathname + href.search,
             headers: {},
         };


### PR DESCRIPTION
If we enable ssl, then the client will only accept connection with secure endpoint.
Even if the response contains http url, with current implementation protocol is hardcoded and it's not possible to switch from secured to non-secure.

Had the case with a load balancer exposing (non-secure) presto with TLS (termination done by load balancer). All communication from nodejs is done with https but some response generated by presto may contain http scheme. The Load balancer will gracefully 301 HTTP to HTTPS but presto-client won't accept non secure communication and won't follow redirection. Another fix could be to just throw an error if we detect a different protocol than what was configured but that's less flexible.