### PR TITLE
Fix when no response from Presto Server

### DIFF
--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -1,12 +1,12 @@
-const { URL } = require('url') ;
+const { URL } = require('url');
 
-var adapterFor = (function() {
+var adapterFor = (function () {
     var adapters = {
         'http:': require('http'),
         'https:': require('https'),
     };
 
-    return function(protocol) {
+    return function (protocol) {
         return adapters[protocol];
     };
 }());
@@ -17,7 +17,7 @@ var QUERY_STATE_CHECK_INTERVAL = 800; // 800ms
 
 exports.version = 'unknown';
 
-var Client = exports.Client = function(args){
+var Client = exports.Client = function (args) {
     if (!args)
         args = {};
     // exports.version set in index.js of project root
@@ -31,7 +31,7 @@ var Client = exports.Client = function(args){
 
     this.catalog = args.catalog;
     this.schema = args.schema;
-    
+
     this.source = args.source || 'nodejs-client';
 
     this.checkInterval = args.checkInterval || QUERY_STATE_CHECK_INTERVAL;
@@ -44,7 +44,7 @@ var Client = exports.Client = function(args){
     }
 };
 
-Client.prototype.request = function(opts, callback) {
+Client.prototype.request = function (opts, callback) {
     var client = this;
     var adapter = adapterFor(client.protocol);
     var contentBody = null;
@@ -52,7 +52,7 @@ Client.prototype.request = function(opts, callback) {
     if (opts instanceof Object) {
         opts.host = client.host;
         opts.port = client.port;
-        if (! opts.headers)
+        if (!opts.headers)
             opts.headers = {};
     } else {
         // "opts" argument should be an URL, probably nextUri
@@ -92,14 +92,14 @@ Client.prototype.request = function(opts, callback) {
 
     var parser = this.jsonParser;
 
-    var req = adapter.request(opts, function(res){
+    var req = adapter.request(opts, function (res) {
         var response_code = res.statusCode;
         var response_data = '';
         res.setEncoding('utf8');
-        res.on('data', function(chunk){
+        res.on('data', function (chunk) {
             response_data += chunk;
         });
-        res.on('end', function(){
+        res.on('end', function () {
             var data = response_data;
             if (response_code < 300 && (data[0] === '{' || data[0] === '[')) {
                 try { data = parser.parse(data); }
@@ -111,7 +111,7 @@ Client.prototype.request = function(opts, callback) {
         });
     });
 
-    req.on('error', function(e){
+    req.on('error', function (e) {
         callback(e);
     });
 
@@ -121,38 +121,38 @@ Client.prototype.request = function(opts, callback) {
     req.end();
 };
 
-Client.prototype.nodes = function(opts, callback) { // TODO: "failed" nodes not supported yet
-    if (! callback) {
+Client.prototype.nodes = function (opts, callback) { // TODO: "failed" nodes not supported yet
+    if (!callback) {
         callback = opts;
         opts = {};
     }
 
-    this.request({ method: 'GET', path: '/v1/node' }, function(error, code, data){
+    this.request({ method: 'GET', path: '/v1/node' }, function (error, code, data) {
         if (error || code !== 200) {
             var message = "node list api returns error" + (data && data.length > 0 ? ":" + data : "");
-            callback({message: message, error: error, code: code});
+            callback({ message: message, error: error, code: code });
             return;
         }
         callback(null, data);
     });
 };
 
-Client.prototype.query = function(query_id, callback) {
-    this.request({ method: 'GET', path: '/v1/query/' + query_id }, function(error, code, data){
+Client.prototype.query = function (query_id, callback) {
+    this.request({ method: 'GET', path: '/v1/query/' + query_id }, function (error, code, data) {
         if (error || code !== 200) {
             var message = "query info api returns error" + (data && data.length > 0 ? ":" + data : "");
-            callback({message: message, error: error, code: code});
+            callback({ message: message, error: error, code: code });
             return;
         }
         callback(null, data);
     });
 };
 
-Client.prototype.kill = function(query_id, callback) {
-    this.request({ method: 'DELETE', path: '/v1/query/' + query_id }, function(error, code, data){
+Client.prototype.kill = function (query_id, callback) {
+    this.request({ method: 'DELETE', path: '/v1/query/' + query_id }, function (error, code, data) {
         if (error || code !== 204) {
             var message = "query kill api returns error" + (data && data.length > 0 ? ":" + data : "");
-            callback({message: message, error: error, code: code});
+            callback({ message: message, error: error, code: code });
             return;
         }
         if (callback)
@@ -160,19 +160,19 @@ Client.prototype.kill = function(query_id, callback) {
     });
 };
 
-Client.prototype.execute = function(opts) {
+Client.prototype.execute = function (opts) {
     this.statementResource(opts);
 };
 
-Client.prototype.statementResource = function(opts) {
+Client.prototype.statementResource = function (opts) {
     var client = this;
     var columns = null;
 
     if ((opts.schema || this.schema) && !(opts.catalog || this.catalog)) {
-        throw {message: "Catalog not specified; catalog is required if schema is specified"}
+        throw { message: "Catalog not specified; catalog is required if schema is specified" }
     }
     if (!opts.success && !opts.callback)
-        throw {message: "callback function 'success' (or 'callback') not specified"};
+        throw { message: "callback function 'success' (or 'callback') not specified" };
 
     var header = {};
     if (opts.catalog || this.catalog) {
@@ -200,13 +200,13 @@ Client.prototype.statementResource = function(opts) {
     var enable_verbose_state_callback = this.enableVerboseStateCallback || false;
 
     var req = { method: 'POST', path: '/v1/statement', headers: header, body: opts.query };
-    client.request(req, function(err, code, data){
+    client.request(req, function (err, code, data) {
         if (err || code !== 200 || (data && data.error)) {
             if (error_callback) {
                 var message = "execution error" + (data && data.length > 0 ? ":" + data : "");
                 if (data && data.error && data.error.message)
                     message = data.error.message;
-                error_callback({message:message, error: (err || data.error), code: code});
+                error_callback({ message: message, error: (err || data.error), code: code });
             }
             return;
         }
@@ -239,12 +239,12 @@ Client.prototype.statementResource = function(opts) {
                 error_message = "nextUri missing in response for POST /v1/statement";
             else if (!data.infoUri)
                 error_message = "infoUri missing in response for POST /v1/statement";
-            error_callback({message: error_message, data: data});
+            error_callback({ message: error_message, data: data });
             return;
         }
         var last_state = null;
         var firstNextUri = data.nextUri; // TODO: check the cases without nextUri for /statement ?
-        var fetch_next = function(next_uri){
+        var fetch_next = function (next_uri) {
             /*
              * 1st time
              {
@@ -294,22 +294,24 @@ Client.prototype.statementResource = function(opts) {
              }
             */
             if (cancel_checker && cancel_checker()) {
-                client.request({ method: 'DELETE', path: next_uri }, function(error, code, data){
+                client.request({ method: 'DELETE', path: next_uri }, function (error, code, data) {
                     if (error || code !== 204) {
-                        error_callback({message: "query fetch canceled, but Presto query cancel may fail", error: error, code: code});
+                        error_callback({ message: "query fetch canceled, but Presto query cancel may fail", error: error, code: code });
                     } else {
-                        error_callback({message: "query fetch canceled by operation"});
+                        error_callback({ message: "query fetch canceled by operation" });
                     }
                 });
                 return;
             }
-            client.request(next_uri, function(error, code, response){
+
+            client.request(next_uri, function (error, code, response) {
+
                 if (error || response.error) {
                     error_callback(error || response.error);
                     return;
                 }
 
-                if (state_callback && (last_state !== response.stats.state || enable_verbose_state_callback)) {
+                if (state_callback && (response && response.stats && last_state !== response.stats.state || enable_verbose_state_callback)) {
                     state_callback(null, response.id, response.stats);
                     last_state = response.stats.state;
                 }
@@ -319,22 +321,23 @@ Client.prototype.statementResource = function(opts) {
                     columns_callback(null, columns);
                 }
 
-                var fetchNextWithTimeout = function(uri, checkInterval) {
-                    setTimeout(function(){ fetch_next(uri); }, checkInterval);
+                var fetchNextWithTimeout = function (uri, checkInterval) {
+                    setTimeout(function () { fetch_next(uri); }, checkInterval);
                 };
 
                 /* presto-main/src/main/java/com/facebook/presto/execution/QueryState.java
                  * QUEUED, PLANNING, STARTING, RUNNING, FINISHED, CANCELED, FAILED
                  */
-                if (response.stats.state === 'QUEUED'
+                if (response && response.stats && (
+                    response.stats.state === 'QUEUED'
                     || response.stats.state === 'PLANNING'
                     || response.stats.state === 'STARTING'
-                    || response.stats.state === 'RUNNING' && !response.data) {
+                    || response.stats.state === 'RUNNING') && !response.data) {
                     fetchNextWithTimeout(response.nextUri, client.checkInterval);
                     return;
                 }
 
-                if (data_callback && response.data) {
+                if (data_callback && response && response.data && response.stats) {
                     data_callback(null, response.data, response.columns, response.stats);
                 }
 
@@ -343,17 +346,24 @@ Client.prototype.statementResource = function(opts) {
                     return;
                 }
 
-                var finishedStats = response.stats;
+                if (response.stats) {
+                    var finishedStats = response.stats;
 
-                if (fetch_info && response.infoUri) {
-                    client.request(response.infoUri, function(error, code, response){
-                        success_callback(null, finishedStats, response);
-                    });
+                    if (fetch_info && response.infoUri) {
+                        client.request(response.infoUri, function (error, code, response) {
+                            success_callback(null, finishedStats, response);
+                        });
+                    }
+                    else {
+                        success_callback(null, finishedStats);
+                    }
+                } else {
+                    error_callback({ error: `ERROR_LIB_PRESTO: ${response ? JSON.stringify(response) : 'NO_RESPONSE'}` });
                 }
-                else {
-                    success_callback(null, finishedStats);
-                }
+
             });
+
+
         };
         fetch_next(firstNextUri);
     });


### PR DESCRIPTION
For some reason if the the client could not receive a response or a response.stats from the Presto Server, the lib will generate a uncaught excepetion, since is javascript and not typescript, is not possible to use elvis operator.

This PR introduces defensive code to address this situation.