### PR TITLE
Allow for headers to be passed in to the client constructor

### DIFF
--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -48,8 +48,6 @@ var Client = exports.Client = function(args){
     }
 };
 
-var req = { method: 'POST', path: '/v1/statement', headers: header, body: opts.query };
-    client.request(req, function(err, code, data){
 Client.prototype.request = function(opts, callback) {
     var client = this;
     var adapter = adapterFor(client.protocol);

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -27,7 +27,6 @@ var Client = exports.Client = function(args){
     this.port = args.port || 8080;
     this.user = args.user || process.env.USER;
     this.basic_auth = args.basic_auth || null;
-    this.adal_auth = args.adal_auth || null;
     this.protocol = 'http:';
 
     this.catalog = args.catalog;

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -44,7 +44,7 @@ var Client = exports.Client = function(args){
     }
 
     if (args.headers) {
-        this.headers = headers
+        this.headers = args.headers
     }
 
 };

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -42,8 +42,14 @@ var Client = exports.Client = function(args){
         this.protocol = 'https:';
         this.ssl = args.ssl;
     }
+
+    if (args.headers) {
+        this.headers = headers
+    }
 };
 
+var req = { method: 'POST', path: '/v1/statement', headers: header, body: opts.query };
+    client.request(req, function(err, code, data){
 Client.prototype.request = function(opts, callback) {
     var client = this;
     var adapter = adapterFor(client.protocol);
@@ -84,6 +90,10 @@ Client.prototype.request = function(opts, callback) {
      */
     if (client.basic_auth)
         opts.headers[Headers.AUTHORIZATION] = 'Basic ' + new Buffer(client.basic_auth.user + ":" + client.basic_auth.password).toString("base64");
+
+    if (client.headers && client.headers instanceof Object) {
+        Object.entries(client.headers).forEach(([header, value]) => opts.headers[header] = value);
+    }
 
     if (opts.body)
         contentBody = opts.body;

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -1,4 +1,4 @@
-const { URL } = require('url') ;
+const url = require('url') ;
 
 var adapterFor = (function() {
     var adapters = {
@@ -27,11 +27,12 @@ var Client = exports.Client = function(args){
     this.port = args.port || 8080;
     this.user = args.user || process.env.USER;
     this.basic_auth = args.basic_auth || null;
+    this.adal_auth = args.adal_auth || null;
     this.protocol = 'http:';
 
     this.catalog = args.catalog;
     this.schema = args.schema;
-    
+
     this.source = args.source || 'nodejs-client';
 
     this.checkInterval = args.checkInterval || QUERY_STATE_CHECK_INTERVAL;
@@ -46,6 +47,7 @@ var Client = exports.Client = function(args){
     if (args.headers) {
         this.headers = headers
     }
+
 };
 
 Client.prototype.request = function(opts, callback) {
@@ -64,7 +66,7 @@ Client.prototype.request = function(opts, callback) {
         opts = {
             method: 'GET',
             host: href.hostname,
-            port: href.port || (href.protocol === 'https:' ? '443' : '80'),
+            port: href.port || client.port, // if given url of next statement doesn't have port, default to client port
             path: href.pathname + href.search,
             headers: {},
         };
@@ -176,19 +178,16 @@ Client.prototype.statementResource = function(opts) {
     var client = this;
     var columns = null;
 
-    if ((opts.schema || this.schema) && !(opts.catalog || this.catalog)) {
-        throw {message: "Catalog not specified; catalog is required if schema is specified"}
-    }
+    if (!opts.catalog && !this.catalog)
+        throw {message: "catalog not specified"};
+    if (!opts.schema && !this.schema)
+        throw {message: "schema not specified"};
     if (!opts.success && !opts.callback)
         throw {message: "callback function 'success' (or 'callback') not specified"};
 
     var header = {};
-    if (opts.catalog || this.catalog) {
-        header[Headers.CATALOG] = opts.catalog || this.catalog;
-    }
-    if (opts.schema || this.schema) {
-        header[Headers.SCHEMA] = opts.schema || this.schema;
-    }
+    header[Headers.CATALOG] = opts.catalog || this.catalog;
+    header[Headers.SCHEMA] = opts.schema || this.schema;
 
     if (opts.session)
         header[Headers.SESSION] = opts.session;
@@ -314,6 +313,19 @@ Client.prototype.statementResource = function(opts) {
             client.request(next_uri, function(error, code, response){
                 if (error || response.error) {
                     error_callback(error || response.error);
+                    return;
+                }
+
+                if (!response || !response.stats) {
+                    // seems like in some rare cases, successful response would not return stats, which will break code in a way that cannot be handled by caller
+                    // attempt to handle this case and send back info
+                    var responseAsString = 'could not parse response as string';
+                    try {
+                        responseAsString = JSON.stringify(response);
+                    } catch (err) {
+                        // ignore error stringifying response (happens if response refs are circular)
+                    }
+                    error_callback({message: "unexpected: successful presto response but undefined or did not contain stats info. response: " + responseAsString, code: code})
                     return;
                 }
 

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -91,7 +91,7 @@ Client.prototype.request = function(opts, callback) {
         opts.headers[Headers.AUTHORIZATION] = 'Basic ' + new Buffer(client.basic_auth.user + ":" + client.basic_auth.password).toString("base64");
 
     if (client.headers && client.headers instanceof Object) {
-        Object.entries(client.headers).forEach(([header, value]) => opts.headers[header] = value);
+        opts.headers = Object.assign({}, opts.headers, client.headers);
     }
 
     if (opts.body)


### PR DESCRIPTION
Small fixes were made and the client constructor was updated to allow for headers to be passed in. This allows more flexibility with the function.