### PR TITLE
Add `custom_auth` option to Client constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Instanciate client object and set default configurations.
     * Pass in a user and password to enable Authorization Basic headers on all requests.
     * basic_auth: {user: "user", password: "password"} (default:null)
   * custom_auth [string]
-    * If given, override HTTP `Authorization` header with the provided string.
+    * Sets HTTP `Authorization` header with the provided string.
+    * Throws exception if `basic_auth` is also given at the same time
   * catalog [string]
     * Default catalog name
   * schema [string]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Instanciate client object and set default configurations.
   * basic_auth [object]
     * Pass in a user and password to enable Authorization Basic headers on all requests.
     * basic_auth: {user: "user", password: "password"} (default:null)
+  * custom_auth [string]
+    * If given, override HTTP `Authorization` header with the provided string.
   * catalog [string]
     * Default catalog name
   * schema [string]

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -99,19 +99,8 @@ Client.prototype.request = function(opts, callback) {
 
     opts.headers[client.headers.USER_AGENT] = this.userAgent;
 
-    if (client.authorization) {
+    if (client.authorization)
         opts.headers[client.headers.AUTHORIZATION] = authorization;
-    } else if (client.basic_auth) {
-        /**
-         * Apply an Authorization header if the user has specified a client.basic_auth object on a
-         * client instance.
-         * @deprecated Please use `basic_auth` arg when instantiating `Client`, or manipulate `authorization` property instead.
-         * @example
-         * var client = new Client();
-         * client.basic_auth = { user: "<user>", password : "<password>"}
-         */
-        opts.headers[client.headers.AUTHORIZATION] = 'Basic ' + new Buffer(client.basic_auth.user + ":" + client.basic_auth.password).toString("base64");
-    }
 
     if (opts.body)
         contentBody = opts.body;

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -38,8 +38,17 @@ var Client = exports.Client = function(args){
     this.host = args.host || 'localhost';
     this.port = args.port || 8080;
     this.user = args.user || process.env.USER;
-    this.basic_auth = args.basic_auth || null;
-    this.custom_auth = args.custom_auth;
+    
+    // HTTP Authorization header
+    if (args.custom_auth && args.basic_auth)
+        throw new Error('Please do not specify basic_auth and custom_auth together.');
+
+    if (args.custom_auth) {
+        this.authorization = args.custom_auth;
+    } else if (args.basic_auth) {
+        this.authorization = 'Basic ' + new Buffer(client.basic_auth.user + ':' + client.basic_auth.password).toString('base64');
+    }
+
     this.protocol = 'http:';
 
     this.catalog = args.catalog;
@@ -90,19 +99,19 @@ Client.prototype.request = function(opts, callback) {
 
     opts.headers[client.headers.USER_AGENT] = this.userAgent;
 
-    /**
-     * Apply an Authorization header if the user
-     * has specified a client.basic_auth object.
-     * client.basic_auth = { user: "<user>", password : "<password>"}
-     */
-    if (client.basic_auth)
+    if (client.authorization) {
+        opts.headers[client.headers.AUTHORIZATION] = authorization;
+    } else if (client.basic_auth) {
+        /**
+         * Apply an Authorization header if the user has specified a client.basic_auth object on a
+         * client instance.
+         * @deprecated Please set basic_auth on constructor, or use `authorization` instead.
+         * @example
+         * var client = new Client();
+         * client.basic_auth = { user: "<user>", password : "<password>"}
+         */
         opts.headers[client.headers.AUTHORIZATION] = 'Basic ' + new Buffer(client.basic_auth.user + ":" + client.basic_auth.password).toString("base64");
-
-    /**
-     * Override Authorization header with custom_auth if given
-     */
-    if (client.custom_auth)
-        opts.headers[client.headers.AUTHORIZATION] = client.custom_auth;
+    }
 
     if (opts.body)
         contentBody = opts.body;

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -39,6 +39,7 @@ var Client = exports.Client = function(args){
     this.port = args.port || 8080;
     this.user = args.user || process.env.USER;
     this.basic_auth = args.basic_auth || null;
+    this.custom_auth = args.custom_auth;
     this.protocol = 'http:';
 
     this.catalog = args.catalog;
@@ -96,6 +97,12 @@ Client.prototype.request = function(opts, callback) {
      */
     if (client.basic_auth)
         opts.headers[client.headers.AUTHORIZATION] = 'Basic ' + new Buffer(client.basic_auth.user + ":" + client.basic_auth.password).toString("base64");
+
+    /**
+     * Override Authorization header with custom_auth if given
+     */
+    if (client.custom_auth)
+        opts.headers[client.headers.AUTHORIZATION] = client.custom_auth;
 
     if (opts.body)
         contentBody = opts.body;

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -41,7 +41,7 @@ var Client = exports.Client = function(args){
     
     // HTTP Authorization header
     if (args.custom_auth && args.basic_auth)
-        throw new Error('Please do not specify basic_auth and custom_auth together.');
+        throw new Error('Please do not specify basic_auth and custom_auth at the same time.');
 
     if (args.custom_auth) {
         this.authorization = args.custom_auth;
@@ -105,7 +105,7 @@ Client.prototype.request = function(opts, callback) {
         /**
          * Apply an Authorization header if the user has specified a client.basic_auth object on a
          * client instance.
-         * @deprecated Please set basic_auth on constructor, or use `authorization` instead.
+         * @deprecated Please use `basic_auth` arg when instantiating `Client`, or manipulate `authorization` property instead.
          * @example
          * var client = new Client();
          * client.basic_auth = { user: "<user>", password : "<password>"}


### PR DESCRIPTION
Add `custom_auth` string argument to `Client` constructor so that developers can customize their HTTP `Authorization` header string, enabling customized authentication process such as Kerberos, OpenID Connect, etc.

Developers must prepare their own `Authorization`, though.

Fixes #47.