### PR TITLE
Fix "authorization does not exist" when custom_auth or basic_auth is specified

### DIFF
--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -100,7 +100,7 @@ Client.prototype.request = function(opts, callback) {
     opts.headers[client.headers.USER_AGENT] = this.userAgent;
 
     if (client.authorization)
-        opts.headers[client.headers.AUTHORIZATION] = authorization;
+        opts.headers[client.headers.AUTHORIZATION] = this.authorization;
 
     if (opts.body)
         contentBody = opts.body;


### PR DESCRIPTION
This PR fixes the following error:
```
ReferenceError: authorization is not defined
    at exports.Client.Client.request (/srv/node_modules/presto-client/lib/presto-client/index.js:103:54)
```