### PR TITLE
add X-Trino-Prepared-Statement to support SQL placeholder

### DIFF
--- a/lib/presto-client/headers.js
+++ b/lib/presto-client/headers.js
@@ -37,6 +37,7 @@ TrinoHeaders.MAX_SIZE = 'X-Trino-Max-Size';
 TrinoHeaders.PAGE_SEQUENCE_ID = 'X-Trino-Page-Sequence-Id';
 
 TrinoHeaders.SESSION = 'X-Trino-Session';
+TrinoHeaders.PREPARE = 'X-Trino-Prepared-Statement';
 
 TrinoHeaders.USER_AGENT = 'User-Agent';
 

--- a/lib/presto-client/headers.js
+++ b/lib/presto-client/headers.js
@@ -15,6 +15,7 @@ Headers.MAX_SIZE = 'X-Presto-Max-Size';
 Headers.PAGE_SEQUENCE_ID = 'X-Presto-Page-Sequence-Id';
 
 Headers.SESSION = 'X-Presto-Session';
+Headers.SESSION = 'X-Presto-Prepared-Statement';
 
 Headers.USER_AGENT = 'User-Agent';
 

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -199,7 +199,7 @@ Client.prototype.statementResource = function(opts) {
         header[client.headers.SCHEMA] = opts.schema || this.schema;
     }
     if (opts.prepares) {
-        header[client.headers.PREPARE] = opts.prepares.map((s, index) => 'query' + index + '=' + s).join(',');
+        header[client.headers.PREPARE] = opts.prepares.map((s, index) => 'query' + index + '=' + urlencode(s)).join(',');
     }
 
 

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -198,6 +198,10 @@ Client.prototype.statementResource = function(opts) {
     if (opts.schema || this.schema) {
         header[client.headers.SCHEMA] = opts.schema || this.schema;
     }
+    if (opts.prepares) {
+        header[client.headers.PREPARE] = opts.prepares.map((s, index) => 'query' + index + '=' + s).join(',');
+    }
+
 
     if (opts.session)
         header[client.headers.SESSION] = opts.session;


### PR DESCRIPTION
```ts
client.execute({
        query: `EXECUTE query0`,
        prepares: [ 'SELECT xxxxxx' ],
});

client.execute({
        query: `EXECUTE query0 USING 1,2,3`,
        prepares: [ 'SELECT * FROM user WHERE id=? AND ……' ],
});
```

add X-Trino-Prepared-Statement to support SQL placeholder