### PR TITLE
Catch Invalid URL errors

### DIFF
--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -77,15 +77,19 @@ Client.prototype.request = function(opts, callback) {
         if (! opts.headers)
             opts.headers = {};
     } else {
-        // "opts" argument should be an URL, probably nextUri
-        var href = new URL(opts);
-        opts = {
-            method: 'GET',
-            host: href.hostname,
-            port: href.port || (href.protocol === 'https:' ? '443' : '80'),
-            path: href.pathname + href.search,
-            headers: {},
-        };
+        try {
+            // "opts" argument should be an URL, probably nextUri
+            var href = new URL(opts);
+            opts = {
+                method: 'GET',
+                host: href.hostname,
+                port: href.port || (href.protocol === 'https:' ? '443' : '80'),
+                path: href.pathname + href.search,
+                headers: {},
+            };
+        } catch (error) {
+            callback(error)
+        }
     }
     opts.protocol = client.protocol;
 

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -88,7 +88,7 @@ Client.prototype.request = function(opts, callback) {
                 headers: {},
             };
         } catch (error) {
-            callback(error)
+            return callback(error);
         }
     }
     opts.protocol = client.protocol;


### PR DESCRIPTION
We had encountered a problem where a custom Presto gateway would return an invalid nextUri in some circumstances. Since the error is raised asynchronously by the `Client#execute` function this lead to an uncaught exception. This change just ensures that the error callback is used in this case instead.