### PR TITLE
Allow passing user header per query

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Attributes of opts [object] are:
 * catalog [string]
 * schema [string]
 * timezone [string :optional]
+* user [string :optional]
 * prepares [array(string)]
   * The array of prepared queries
   * Prepared queries can be referred as `queryN`(N: index) like `query0`, `query1` in the query specified as `query`

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -95,7 +95,7 @@ Client.prototype.request = function(opts, callback) {
 
     opts = Object.assign({}, opts, client.ssl);
 
-    if (client.user)
+    if (client.user && !opts.headers[client.headers.USER])
         opts.headers[client.headers.USER] = client.user;
 
     if (client.source)
@@ -201,6 +201,9 @@ Client.prototype.statementResource = function(opts) {
     }
     if (opts.schema || this.schema) {
         header[client.headers.SCHEMA] = opts.schema || this.schema;
+    }
+    if (opts.user || this.user) {
+        header[client.headers.USER] = opts.user || this.user;
     }
     if (opts.prepares) {
         header[client.headers.PREPARE] = opts.prepares.map((s, index) => 'query' + index + '=' + urlencode(s)).join(',');

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -74,6 +74,8 @@ Client.prototype.request = function(opts, callback) {
     if (opts instanceof Object) {
         opts.host = client.host;
         opts.port = client.port;
+        if (! opts.user)
+            opts.user = client.user
         if (! opts.headers)
             opts.headers = {};
     } else {
@@ -95,8 +97,8 @@ Client.prototype.request = function(opts, callback) {
 
     opts = Object.assign({}, opts, client.ssl);
 
-    if (client.user && !opts.headers[client.headers.USER])
-        opts.headers[client.headers.USER] = client.user;
+    if (opts.user)
+        opts.headers[client.headers.USER] = opts.user;
 
     if (client.source)
         opts.headers[client.headers.SOURCE] = client.source;
@@ -202,9 +204,6 @@ Client.prototype.statementResource = function(opts) {
     if (opts.schema || this.schema) {
         header[client.headers.SCHEMA] = opts.schema || this.schema;
     }
-    if (opts.user || this.user) {
-        header[client.headers.USER] = opts.user || this.user;
-    }
     if (opts.prepares) {
         header[client.headers.PREPARE] = opts.prepares.map((s, index) => 'query' + index + '=' + urlencode(s)).join(',');
     }
@@ -227,7 +226,7 @@ Client.prototype.statementResource = function(opts) {
 
     var enable_verbose_state_callback = this.enableVerboseStateCallback || false;
 
-    var req = { method: 'POST', path: '/v1/statement', headers: header, body: opts.query };
+    var req = { method: 'POST', path: '/v1/statement', headers: header, body: opts.query, user: opts.user };
     client.request(req, function(err, code, data){
         if (err || code !== 200 || (data && data.error)) {
             if (error_callback) {


### PR DESCRIPTION
This change allows setting the `X-PRESTO-USER` header per query which is helpful for limiting (queueing) queries per application user.