### PR TITLE
chore(license): set to current instead of unknown

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014- tagomoris
+Copyright (c) 2014-current tagomoris
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
`2014-` seems like wrong meaning for current year, better write it to `2014-current`