### PR TITLE
Added support for user provided headers in the execute method

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Attributes of opts [object] are:
     ```
 * info [boolean :optional]
   * fetch query info (execution statistics) for success callback, or not (default false)
+* headers [object :optional]
+  * additional headers to be included in the request, check the full list for [Trino](https://trino.io/docs/current/develop/client-protocol.html#client-request-headers) and [Presto](https://prestodb.io/docs/current/develop/client-protocol.html#client-request-headers) engines
 * cancel [function() :optional]
   * client stops fetch of query results if this callback returns `true`
 * state [function(error, query_id, stats) :optional]

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -197,7 +197,7 @@ Client.prototype.statementResource = function(opts) {
     if (!opts.success && !opts.callback)
         throw {message: "callback function 'success' (or 'callback') not specified"};
 
-    var header = {};
+    var header = Object.assign({}, opts.headers);
     if (opts.catalog || this.catalog) {
         header[client.headers.CATALOG] = opts.catalog || this.catalog;
     }


### PR DESCRIPTION
This is a simple but much needed change to allow users to provide values for the headers that are not already supported by this client (full list here: https://prestodb.io/docs/current/develop/client-protocol.html).