### PR TITLE
Update .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+node_modules/
+.DS_Store
 .devcontainer
+npm-debug.log*
+package-lock.json


### PR DESCRIPTION
PR adds some common files to the `.gitignore` file that I have in my working directory after playing around with the repo that it doesn't seem like you or anyone would largely want checked in. The only file here that could be checked in would be the `package-lock.json` file, but I've seen people debate either way for libraries to bother with a lock file in the repo itself for development.