### PR TITLE
Retry for 502-504 codes, fail on >= 400 codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Instanciate client object and set default configurations.
   * engine [string]
     * Change headers set. Added for compatibility with Trino.
     * Available options: presto, trino (default: presto)
+  * timeout [integer :optional]
+    * The seconds that a query is allowed to run before it starts returning results, defaults to 60 seconds. Set to `null` or `0` to disable.
 
 return value: client instance object
 
@@ -101,6 +103,7 @@ Attributes of opts [object] are:
   * fetch query info (execution statistics) for success callback, or not (default false)
 * headers [object :optional]
   * additional headers to be included in the request, check the full list for [Trino](https://trino.io/docs/current/develop/client-protocol.html#client-request-headers) and [Presto](https://prestodb.io/docs/current/develop/client-protocol.html#client-request-headers) engines
+* timeout [integer :optional]
 * cancel [function() :optional]
   * client stops fetch of query results if this callback returns `true`
 * state [function(error, query_id, stats) :optional]
@@ -124,6 +127,8 @@ Attributes of opts [object] are:
     * same as data of `columns` callback
   * stats (optional)
     * runtime statistics object of query
+* retry [function() :optional]
+  * called if a request was retried due to server returning `502`, `503`, or `504`
 * success [function(error, stats, info) :optional]
   * called once when all results are fetched (default: value of `callback`)
 * error [function(error) :optional]

--- a/index.spec.js
+++ b/index.spec.js
@@ -1,11 +1,11 @@
 // Before running the tests, make sure to start the docker containers
 
-var { describe, expect, test } = require('@jest/globals');
-var os = require('os');
+var { beforeAll, beforeEach, afterAll, describe, expect, test } = require('@jest/globals');
+var http = require('http');
 var Client = require('./index').Client;
 
 test('cannot use basic and custom auth', function(){
-  expect(function() {
+  expect(function(){
     new Client({
       host: 'localhost',
       port: 8080,
@@ -53,6 +53,266 @@ describe.each([['presto'], ['trino']])('%s', function(engine){
         var tableName = engine === 'presto' ? 'tpch.tiny.non_existent_table' : "'tpch.tiny.non_existent_table'";
         expect(error.message).toEqual((engine === 'presto' ? '' : 'line 1:15: ') + 'Table ' + tableName + ' does not exist');
         done();
+      },
+    });
+  });
+
+  test('query with no text', function(done){
+    expect.assertions(1);
+    client.execute({
+      query: '',
+      callback: function(error){
+        expect(error).toEqual({
+          code: 400,
+          error: new Error('execution error:SQL statement is empty'),
+          message: "execution error:SQL statement is empty",
+        });
+        done();
+      },
+    });
+  });
+});
+
+describe('when server returns non-200 response', function(){
+  describe('the client should retry for 50x code', function(){
+    describe.each([502, 503, 504])('the client retries for %i code', function(statusCode){
+      var responses = {
+        '/v1/statement': {
+            "stats": {
+                "state": "QUEUED",
+            },
+            "nextUri": "http://localhost:8111/v1/statement/20140120_032523_00000_32v8g/1",
+            "infoUri": "http://localhost:8111/v1/query/20140120_032523_00000_32v8g",
+            "id": "20140120_032523_00000_32v8g",
+        },
+        '/v1/statement/20140120_032523_00000_32v8g/1': {
+          "stats": {
+              "state": "FINISHED",
+          },
+          "columns": [ { "type": "integer", "name": "col" } ],
+          "data": [ [ 1 ] ],
+          "infoUri": "http://localhost:8111/v1/query/20140120_032523_00000_32v8g",
+          "id": "20140120_032523_00000_32v8g"
+        }
+      };
+
+      var server;
+      var count;
+
+      beforeAll(function(done) {
+        server = http.createServer(function(req, res){
+          if (count % 2 === 0) {
+            res.statusCode = statusCode;
+          } else {
+            res.statusCode = 200;
+            res.setHeader('Content-Type', 'application/json');
+            res.write(JSON.stringify(responses[req.url]));
+          }
+          count++;
+          res.end();
+        });
+        server.listen(8111, function(){
+          done();
+        });
+      });
+
+      beforeEach(function(){
+        count = 0;
+      });
+
+      afterAll(function(done){
+        server.close(function(){
+          done();
+        });
+      });
+
+      test('the client returns success', function(done){
+        expect.assertions(7);
+        var client = new Client({
+          host: 'localhost',
+          port: 8111,
+        });
+        client.execute({
+          query: 'SELECT 1 AS col',
+          data: function(error, data, columns){
+            expect(error).toBeNull();
+            expect(data).toEqual([[1]]);
+            expect(columns).toHaveLength(1);
+            expect(columns[0]).toEqual(expect.objectContaining({ name: 'col', type: 'integer' }));
+          },
+          retry: function(){
+            // this should be called twice
+            expect(true).toBe(true);
+          },
+          callback: function(error){
+            expect(error).toBeNull();
+            done();
+          },
+        });
+      });
+    });
+  });
+
+  describe.each([404, 500])('the client fails for %i code', function(statusCode){
+    describe.each([0, 1])('the client fails after %i requests', function(failAfter){
+      var responses = {
+        '/v1/statement': {
+            "stats": {
+                "state": "QUEUED",
+            },
+            "nextUri": "http://localhost:8111/v1/statement/20140120_032523_00000_32v8g/1",
+            "infoUri": "http://localhost:8111/v1/query/20140120_032523_00000_32v8g",
+            "id": "20140120_032523_00000_32v8g",
+        },
+        '/v1/statement/20140120_032523_00000_32v8g/1': {
+          "stats": {
+              "state": "FINISHED",
+          },
+          "columns": [ { "type": "integer", "name": "col" } ],
+          "data": [ [ 1 ] ],
+          "infoUri": "http://localhost:8111/v1/query/20140120_032523_00000_32v8g",
+          "id": "20140120_032523_00000_32v8g"
+        }
+      };
+
+      var server;
+      var count;
+
+      beforeAll(function(done) {
+        server = http.createServer(function(req, res){
+          if (count === failAfter) {
+            res.statusCode = statusCode;
+          } else {
+            count++;
+            res.statusCode = 200;
+            res.setHeader('Content-Type', 'application/json');
+            res.write(JSON.stringify(responses[req.url]));
+          }
+          res.end();
+        });
+        server.listen(8111, function(){
+          done();
+        });
+      });
+
+      beforeEach(function(){
+        count = 0;
+      });
+
+      afterAll(function(done){
+        server.close(function(){
+          done();
+        });
+      });
+
+      test('the client returns error', function(done){
+        expect.assertions(1);
+        var client = new Client({
+          host: 'localhost',
+          port: 8111,
+        });
+        client.execute({
+          query: 'SELECT 1 AS col',
+          data: function(){
+            done('should not have data');
+          },
+          callback: function(error){
+            const errorObj = new Error('execution error:invalid response code (' + statusCode + ')');
+            expect(error).toEqual(failAfter === 0 ? {
+              "code": statusCode,
+              "error": errorObj,
+              "message": "execution error",
+            } : errorObj);
+            done();
+          },
+        });
+      });
+    });
+  });
+});
+
+describe('when server returns invalid json with 200 code', function(){
+  beforeAll(function(done) {
+    server = http.createServer(function(req, res){
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.write('this is invalid{json}');
+      res.end();
+    });
+    server.listen(8111, function(){
+      done();
+    });
+  });
+
+  afterAll(function(done){
+    server.close(function(){
+      done();
+    });
+  });
+  test('client returns error', function(done){
+    expect.assertions(1);
+    var client = new Client({
+      host: 'localhost',
+      port: 8111,
+    });
+    client.execute({
+      query: 'SELECT 1',
+      data: function(){
+        done('no data should have been returned');
+      },
+      error: function(error){
+        expect(error).toEqual({
+          code: 200,
+          error: new Error("execution error:could not parse response"),
+          message: "execution error:this is invalid{json}"
+        });
+        done();
+      },
+      success: function(){
+        done('success should not have been called');
+      },
+    });
+  });
+});
+
+describe('when timeout is set', function(){
+  var server;
+
+  beforeAll(function(done) {
+    server = http.createServer(function(req, res){
+      res.statusCode = 502;
+      res.end();
+    });
+    server.listen(8111, function(){
+      done();
+    });
+  });
+
+  afterAll(function(done){
+    server.close(function(){
+      done();
+    });
+  });
+
+  test('the query times out', function(done) {
+    expect.assertions(1);
+    var client = new Client({
+      host: 'localhost',
+      port: 8111,
+      timeout: 2,
+    });
+    client.execute({
+      query: 'SELECT 1 AS col',
+      timeout: 1,
+      data: function(){
+        done('no data should be returned');
+      },
+      error: function(error){
+        expect(error).toEqual({"message": "execution error:query timed out"});
+        done();
+      },
+      success: function(){
+        done('success should not have been called');
       },
     });
   });

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -60,6 +60,8 @@ var Client = exports.Client = function(args){
     this.enableVerboseStateCallback = args.enableVerboseStateCallback || false;
     this.jsonParser = args.jsonParser || JSON;
 
+    this.timeout = typeof args.timeout !== 'undefined' ? args.timeout : 60;
+
     if (args.ssl) {
         this.protocol = 'https:';
         this.ssl = args.ssl;
@@ -124,13 +126,24 @@ Client.prototype.request = function(opts, callback) {
         });
         res.on('end', function(){
             var data = response_data;
-            if (response_code < 300 && (data[0] === '{' || data[0] === '[')) {
-                try { data = parser.parse(data); }
-                catch (x) {
-                    /* ignore json parse error (and don't parse) for non-json content body */
+            var error = null;
+            // Only a 200 response code should be considered successful
+            if (response_code === 200) {
+                try {
+                    if (data[0] !== '{' && data[0] !== '[') {
+                        throw new Error();
+                    }
+                    data = parser.parse(data);
+                } catch (_) {
+                    /* ignore actual error, and give a generic message */
+                    error = new Error("execution error:could not parse response");
                 }
             }
-            callback(null, response_code, data);
+            else
+            {
+                error = new Error("execution error:" + (data ? data : "invalid response code (" + response_code + ")"));
+            }
+            callback(error, response_code, data);
         });
     });
 
@@ -142,6 +155,8 @@ Client.prototype.request = function(opts, callback) {
         req.write(contentBody);
 
     req.end();
+
+    return req;
 };
 
 Client.prototype.nodes = function(opts, callback) { // TODO: "failed" nodes not supported yet
@@ -220,167 +235,212 @@ Client.prototype.statementResource = function(opts) {
     var state_callback = opts.state;
     var columns_callback = opts.columns;
     var data_callback = opts.data;
+    var retry_callback = opts.retry;
     var success_callback = opts.success || opts.callback;
     var error_callback = opts.error || opts.callback;
+    var timeout_value = typeof opts.timeout !== 'undefined' ? opts.timeout : this.timeout;
 
     var enable_verbose_state_callback = this.enableVerboseStateCallback || false;
+    var current_req = null;
+    var last_state = null;
+    var query_id = null;
+    var timed_out = false;
 
-    var req = { method: 'POST', path: '/v1/statement', headers: header, body: opts.query, user: opts.user };
-    client.request(req, function(err, code, data){
-        if (err || code !== 200 || (data && data.error)) {
-            if (error_callback) {
-                var message = "execution error" + (data && data.length > 0 ? ":" + data : "");
-                if (data && data.error && data.error.message)
-                    message = data.error.message;
-                error_callback({message:message, error: (err || data.error), code: code});
-            }
+    var timeout = !timeout_value ? null : setTimeout(() => {
+        timed_out = true;
+        if (query_id) {
+            client.kill(query_id, function() {
+                // don't worry if this fails
+            });
+        }
+        if (current_req) {
+            current_req.destroy();
+        }
+        error_callback({message: "execution error:query timed out"});
+    }, timeout_value * 1000);
+
+    var clear_timeout = function(){
+        if (timeout) {
+            clearTimeout(timeout);
+        }
+        timeout = null;
+    }
+
+    /*
+    * 1st call:
+        {
+            "stats": {
+                "processedBytes": 0,
+                "processedRows": 0,
+                "wallTimeMillis": 0,
+                "cpuTimeMillis": 0,
+                "userTimeMillis": 0,
+                "state": "QUEUED",
+                "scheduled": false,
+                "nodes": 0,
+                "totalSplits": 0,
+                "queuedSplits": 0,
+                "runningSplits": 0,
+                "completedSplits": 0,
+            },
+            "nextUri": "http://localhost:8080/v1/statement/20140120_032523_00000_32v8g/1",
+            "infoUri": "http://localhost:8080/v1/query/20140120_032523_00000_32v8g",
+            "id": "20140120_032523_00000_32v8g"
+        };
+        * 2+ time
+        {
+            "stats": {
+                "rootStage": {
+                    "subStages": [
+                        {
+                            "subStages": [],
+                            "processedBytes": 83103149,
+                            "processedRows": 2532704,
+                            "wallTimeMillis": 20502,
+                            "cpuTimeMillis": 3431,
+                            "userTimeMillis": 3210,
+                            "stageId": "1",
+                            "state": "FINISHED",
+                            "done": true,
+                            "nodes": 3,
+                            "totalSplits": 420,
+                            "queuedSplits": 0,
+                            "runningSplits": 0,
+                            "completedSplits": 420
+                        }
+                    ],
+                    // same as substage
+                },
+                // same as substage
+                "state": "RUNNING",
+            },
+            "data": [ [ 1266352 ] ],
+            "columns": [ { "type": "bigint", "name": "cnt" } ],
+            "nextUri": "http://localhost:8080/v1/statement/20140120_032523_00000_32v8g/2",
+            "partialCancelUri": "http://10.0.0.0:8080/v1/stage/20140120_032523_00000_32v8g.0",
+            "infoUri": "http://localhost:8080/v1/query/20140120_032523_00000_32v8g",
+            "id": "20140120_032523_00000_32v8g"
+        }
+        * final state
+        {
+            "stats": {
+                // ....
+                "state": "FINISHED",
+            },
+            "columns": [ { "type": "bigint", "name": "cnt" } ],
+            "infoUri": "http://localhost:8080/v1/query/20140120_032523_00000_32v8g",
+            "id": "20140120_032523_00000_32v8g"
+        }
+    */
+
+    var first_request = true;
+    var fetch = function(uri_obj){
+        // we have already timed out and shown an error, so abort out
+        if (timed_out) {
             return;
         }
-        /*
-          var data = {
-              "stats": {
-                  "processedBytes": 0,
-                  "processedRows": 0,
-                  "wallTimeMillis": 0,
-                  "cpuTimeMillis": 0,
-                  "userTimeMillis": 0,
-                  "state": "QUEUED",
-                  "scheduled": false,
-                  "nodes": 0,
-                  "totalSplits": 0,
-                  "queuedSplits": 0,
-                  "runningSplits": 0,
-                  "completedSplits": 0,
-              },
-              "nextUri": "http://localhost:8080/v1/statement/20140120_032523_00000_32v8g/1",
-              "infoUri": "http://localhost:8080/v1/query/20140120_032523_00000_32v8g",
-              "id": "20140120_032523_00000_32v8g"
-          };
-        */
-        if (!data.id || !data.nextUri || !data.infoUri) {
-            var error_message = null;
-            if (!data.id)
-                error_message = "query id missing in response for POST /v1/statement";
-            else if (!data.nextUri)
-                error_message = "nextUri missing in response for POST /v1/statement";
-            else if (!data.infoUri)
-                error_message = "infoUri missing in response for POST /v1/statement";
-            error_callback({message: error_message, data: data});
-            return;
-        }
-        var last_state = null;
-        var firstNextUri = data.nextUri; // TODO: check the cases without nextUri for /statement ?
-        var fetch_next = function(next_uri){
-            /*
-             * 1st time
-             {
-                 "stats": {
-                     "rootStage": {
-                         "subStages": [
-                             {
-                                 "subStages": [],
-                                 "processedBytes": 83103149,
-                                 "processedRows": 2532704,
-                                 "wallTimeMillis": 20502,
-                                 "cpuTimeMillis": 3431,
-                                 "userTimeMillis": 3210,
-                                 "stageId": "1",
-                                 "state": "FINISHED",
-                                 "done": true,
-                                 "nodes": 3,
-                                 "totalSplits": 420,
-                                 "queuedSplits": 0,
-                                 "runningSplits": 0,
-                                 "completedSplits": 420
-                             }
-                         ],
-                         // same as substage
-                     },
-                     // same as substage
-                     "state": "RUNNING",
-                 },
-                 "data": [ [ 1266352 ] ],
-                 "columns": [ { "type": "bigint", "name": "cnt" } ],
-                 "nextUri": "http://localhost:8080/v1/statement/20140120_032523_00000_32v8g/2",
-                 "partialCancelUri": "http://10.0.0.0:8080/v1/stage/20140120_032523_00000_32v8g.0",
-                 "infoUri": "http://localhost:8080/v1/query/20140120_032523_00000_32v8g",
-                 "id": "20140120_032523_00000_32v8g"
-             }
-            */
-            /*
-             * 2nd time
-             {
-                 "stats": {
-                     // ....
-                     "state": "FINISHED",
-                 },
-                 "columns": [ { "type": "bigint", "name": "cnt" } ],
-                 "infoUri": "http://localhost:8080/v1/query/20140120_032523_00000_32v8g",
-                 "id": "20140120_032523_00000_32v8g"
-             }
-            */
-            if (cancel_checker && cancel_checker()) {
-                client.request({ method: 'DELETE', path: next_uri }, function(error, code, data){
-                    if (error || code !== 204) {
-                        error_callback({message: "query fetch canceled, but Presto query cancel may fail", error: error, code: code});
-                    } else {
-                        error_callback({message: "query fetch canceled by operation"});
-                    }
-                });
-                return;
-            }
-            client.request(next_uri, function(error, code, response){
-                if (error || response.error) {
-                    error_callback(error || response.error);
-                    return;
-                }
-
-                if (state_callback && (last_state !== response.stats.state || enable_verbose_state_callback)) {
-                    state_callback(null, response.id, response.stats);
-                    last_state = response.stats.state;
-                }
-
-                if (columns_callback && response.columns && !columns) {
-                    columns = response.columns;
-                    columns_callback(null, columns);
-                }
-
-                var fetchNextWithTimeout = function(uri, checkInterval) {
-                    setTimeout(function(){ fetch_next(uri); }, checkInterval);
-                };
-
-                /* presto-main/src/main/java/com/facebook/presto/execution/QueryState.java
-                 * QUEUED, PLANNING, STARTING, RUNNING, FINISHED, CANCELED, FAILED
-                 */
-                if (response.stats.state === 'QUEUED'
-                    || response.stats.state === 'PLANNING'
-                    || response.stats.state === 'STARTING'
-                    || response.stats.state === 'RUNNING' && !response.data) {
-                    fetchNextWithTimeout(response.nextUri, client.checkInterval);
-                    return;
-                }
-
-                if (data_callback && response.data) {
-                    data_callback(null, response.data, response.columns, response.stats);
-                }
-
-                if (response.nextUri) {
-                    fetchNextWithTimeout(response.nextUri, client.checkInterval);
-                    return;
-                }
-
-                var finishedStats = response.stats;
-
-                if (fetch_info && response.infoUri) {
-                    client.request(response.infoUri, function(error, code, response){
-                        success_callback(null, finishedStats, response);
-                    });
-                }
-                else {
-                    success_callback(null, finishedStats);
+        if (!first_request && cancel_checker && cancel_checker()) {
+            clear_timeout();
+            client.request({ method: 'DELETE', path: uri_obj }, function(error, code, data){
+                if (error || code !== 204) {
+                    error_callback({message: "query fetch canceled, but Presto query cancel may fail", error: error, code: code});
+                } else {
+                    error_callback({message: "query fetch canceled by operation"});
                 }
             });
-        };
-        fetch_next(firstNextUri);
-    });
+            return;
+        }
+        current_req = client.request(uri_obj, function(error, code, response){
+            // same as above, we have already timed out and shown an error, so abort out
+            if (timed_out) {
+                return;
+            }
+            if ([502, 503, 504].includes(code)) {
+                setTimeout(function(){
+                    fetch(uri_obj);
+                }, Math.floor(Math.random() * 51) + 50); // random in 50-100ms
+                if (retry_callback) {
+                    retry_callback();
+                }
+                return;
+            }
+
+            if (error || (response && response.error)) {
+                clear_timeout();
+                if (first_request) {
+                    var message = "execution error" + (response && response.length > 0 ? ":" + response : "");
+                    if (response && response.error && response.error.message)
+                        message = response.error.message;
+                    error_callback({message, error: (error || response.error), code});
+                } else {
+                    error_callback(error || response.error);
+                }
+                return;
+            }
+
+            if (first_request && (!response.id || !response.nextUri || !response.infoUri)) {
+                clear_timeout();
+                var error_message = null;
+                if (!response.id)
+                    error_message = "query id missing in response for POST /v1/statement";
+                else if (!response.nextUri)
+                    error_message = "nextUri missing in response for POST /v1/statement";
+                else if (!response.infoUri)
+                    error_message = "infoUri missing in response for POST /v1/statement";
+                error_callback({message: error_message, data: response});
+                return;
+            }
+
+            first_request = false;
+            query_id = response.id || query_id;
+
+            if (state_callback && (last_state !== response.stats.state || enable_verbose_state_callback)) {
+                state_callback(null, response.id, response.stats);
+                last_state = response.stats.state;
+            }
+
+            if (columns_callback && response.columns && !columns) {
+                columns = response.columns;
+                columns_callback(null, columns);
+            }
+
+            var fetchNextWithTimeout = function(uri, checkInterval) {
+                setTimeout(function(){ fetch(uri); }, checkInterval);
+            };
+
+            /* presto-main/src/main/java/com/facebook/presto/execution/QueryState.java
+                * QUEUED, PLANNING, STARTING, RUNNING, FINISHED, CANCELED, FAILED
+                */
+            if (response.stats.state === 'QUEUED'
+                || response.stats.state === 'PLANNING'
+                || response.stats.state === 'STARTING'
+                || response.stats.state === 'RUNNING' && !response.data) {
+                fetchNextWithTimeout(response.nextUri, client.checkInterval);
+                return;
+            }
+
+            if (data_callback && response.data) {
+                data_callback(null, response.data, response.columns, response.stats);
+            }
+
+            if (response.nextUri) {
+                fetchNextWithTimeout(response.nextUri, client.checkInterval);
+                return;
+            }
+
+            clear_timeout();
+
+            var finishedStats = response.stats;
+
+            if (fetch_info && response.infoUri) {
+                client.request(response.infoUri, function(error, code, response){
+                    success_callback(null, finishedStats, response);
+                });
+            }
+            else {
+                success_callback(null, finishedStats);
+            }
+        });
+    };
+    fetch({ method: 'POST', path: '/v1/statement', headers: header, body: opts.query, user: opts.user });
 };


### PR DESCRIPTION
Closes #72 

PR modifies the behavior of the client such that:
* If the response returns a `502`, `503`, or `504` code, then the request will be retried after 50-100ms
* If the response returns with >= 400 code that does not match above, then throw an error

and that this happens consistently whether the codes happen on the first request or a subsequent request. Previously, all of these codes would throw an error only on the first request, while all subsequent requests would trigger an uncaught exception.

I included tests that validate the proper behavior for triggering these codes on the first `POST` call to `/v1/statement` as well as the subsequent `GET` call to `/v1/statement/...`.