### PR TITLE
Require using error or callback handler for execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Attributes of opts [object] are:
 * callback [function(error, stats) :optional]
   * callback for query completion (both of success and fail)
   * one of `callback` or `success` must be specified
+  * one of `callback` or `error` must be specified
 
 Callbacks order (success query) is: columns -> data (-> data xN) -> success (or callback)
 

--- a/index.spec.js
+++ b/index.spec.js
@@ -18,6 +18,38 @@ test('cannot use basic and custom auth', function(){
   }).toThrow(new Error('Please do not specify basic_auth and custom_auth at the same time.'));
 });
 
+describe('execute errors', function(){
+  const client = new Client();
+
+  test('error if do not define success or callback', function(){
+    expect(function() {
+      client.execute({
+        query: 'SELECT 1',
+        error: () => {},
+      });
+    }).toThrow(new Error("callback function 'success' (or 'callback') not specified"));
+  });
+
+  test('error if do not define error or callback', function(){
+    expect(function() {
+      client.execute({
+        query: 'SELECT 1',
+        success: () => {},
+      })
+    }).toThrow(new Error("callback function 'error' (or 'callback') not specified"));
+  });
+
+  test('error if schema provided and not catalog', function() {
+    expect(function() {
+      client.execute({
+        query: 'SELECT 1',
+        schema: 'test',
+        callback: () => {},
+      });
+    }).toThrow(new Error('Catalog not specified; catalog is required if schema is specified'))
+  })
+});
+
 describe.each([['presto'], ['trino']])('%s', function(engine){
   const client = new Client({
     host: 'localhost',

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -196,6 +196,8 @@ Client.prototype.statementResource = function(opts) {
     }
     if (!opts.success && !opts.callback)
         throw {message: "callback function 'success' (or 'callback') not specified"};
+    if (!opts.error && !opts.callback)
+        throw {message: "callback function 'error' (or 'callback') not specified"};
 
     var header = Object.assign({}, opts.headers);
     if (opts.catalog || this.catalog) {


### PR DESCRIPTION
PR closes #71

This makes it so that either `error` or `callback` are specified as options to `execute`, so that if an error occurs, there's a function to be called to alert the user. This avoids the current situation where if an error happens and neither are defined then a `TypeError` is raised. The README has also been adjusted to document this requirement.

An alternative approach would be to just not forward the error to the user, though I think it's best practices to force the user to handle errors, even if it's just them ignoring it themselves.