### PR TITLE
Update image used for presto container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   presto:
-    image: ahanaio/prestodb-sandbox:0.281
+    image: ghcr.io/popsql/prestodb-sandbox:0.281
     # there is no arm64 version of this image
     platform: linux/amd64
     ports:


### PR DESCRIPTION
PR updates the source used for the `prestodb-sandbox` image, as the existing one was deleted from Docker Hub. Earlier this year IBM acquired Ahana, and last week it looks like they completed deleted all resources that Ahana had on a number of sites, including Docker Hub.

The image replacing it with is the exact same image, just uploaded to a new place. In theory, at some point it should be possible to use the `prestodb/presto` images, but currently using them requires creating and mounting a number of `etc/` config files, vs just having the image be self-contained.
