### PR TITLE
Follow redirects on server responses

### DIFF
--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -2,8 +2,8 @@ const { URL } = require('url') ;
 
 var adapterFor = (function() {
     var adapters = {
-        'http:': require('http'),
-        'https:': require('https'),
+        'http:': require('follow-redirects/http'),
+        'https:': require('follow-redirects/https'),
     };
 
     return function(protocol) {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   },
   "devDependencies": {
     "jest": "29.5.0"
+  },
+  "dependencies": {
+    "follow-redirects": "^1.15.3"
   }
 }


### PR DESCRIPTION
Closes #80 

PR implements the [`follow-redirects`](https://www.npmjs.com/package/follow-redirects) library into the client, such that if a request to the server returns a 301, it'll be followed, instead of the user getting an `execution error:invalid response code (301)`  error. This is principally to handle the case where a request goes to a HTTP endpoint behind a load balancer, and the load balancer responds with a 301 to upgrade the request to HTTPS.

`follow-redirects` does offer [some options](https://www.npmjs.com/package/follow-redirects#per-request-options) (e.g. whether to follow redirects at all, amount of redirects to follow, etc.), but I don't think it's really meaningful to expose them to end users of the client as I think pretty much all consumers are probably going to be fine with the defaults.