### PR TITLE
Simplify setting up Header objects

### DIFF
--- a/lib/presto-client/headers.js
+++ b/lib/presto-client/headers.js
@@ -1,45 +1,43 @@
-var Headers = exports.Headers = function(){
+var Headers = exports.Headers = {};
+var TrinoHeaders = exports.TrinoHeaders = {};
+
+// All values in this array are prefixed with X-Presto-/X-Trino-,
+// with the key being the value uppercased and dashes replaced
+// with underscores, e.g. `Max-Size` becomes
+// `{ MAX_SIZE: 'X-Presto-Max-Size' }` on Headers object.
+const commonPrefix = [
+  'User',
+  'Source',
+  'Catalog',
+  'Schema',
+  'Time-Zone',
+  'Current-State',
+  'Max-Wait',
+  'Max-Size',
+  'Page-Sequence-Id',
+  'Session',
+  'Prepared-Statement',
+];
+const legacyPrefix = {
+  'PREPARE': 'Prepared-Statement',
 };
+const common = [
+  'User-Agent',
+  'Authorization',
+];
 
-Headers.USER = 'X-Presto-User';
-
-Headers.SOURCE = 'X-Presto-Source';
-Headers.CATALOG = 'X-Presto-Catalog';
-Headers.SCHEMA = 'X-Presto-Schema';
-
-Headers.TIME_ZONE = 'X-Presto-Time-Zone';
-
-Headers.CURRENT_STATE = 'X-Presto-Current-State';
-Headers.MAX_WAIT = 'X-Presto-Max-Wait';
-Headers.MAX_SIZE = 'X-Presto-Max-Size';
-Headers.PAGE_SEQUENCE_ID = 'X-Presto-Page-Sequence-Id';
-
-Headers.SESSION = 'X-Presto-Session';
-Headers.PREPARE = 'X-Presto-Prepared-Statement';
-
-Headers.USER_AGENT = 'User-Agent';
-
-Headers.AUTHORIZATION = 'Authorization';
-
-var TrinoHeaders = exports.TrinoHeaders = function(){
-};
-
-TrinoHeaders.USER = 'X-Trino-User';
-
-TrinoHeaders.SOURCE = 'X-Trino-Source';
-TrinoHeaders.CATALOG = 'X-Trino-Catalog';
-TrinoHeaders.SCHEMA = 'X-Trino-Schema';
-
-TrinoHeaders.TIME_ZONE = 'X-Trino-Time-Zone';
-
-TrinoHeaders.CURRENT_STATE = 'X-Trino-Current-State';
-TrinoHeaders.MAX_WAIT = 'X-Trino-Max-Wait';
-TrinoHeaders.MAX_SIZE = 'X-Trino-Max-Size';
-TrinoHeaders.PAGE_SEQUENCE_ID = 'X-Trino-Page-Sequence-Id';
-
-TrinoHeaders.SESSION = 'X-Trino-Session';
-TrinoHeaders.PREPARE = 'X-Trino-Prepared-Statement';
-
-TrinoHeaders.USER_AGENT = 'User-Agent';
-
-TrinoHeaders.AUTHORIZATION = 'Authorization';
+const transform = (key) => {
+  return key.replace('-', '_').toUpperCase();
+}
+commonPrefix.forEach((header) => {
+  Headers[transform(header)] = `X-Presto-${header}`;
+  TrinoHeaders[transform(header)] = `X-Trino-${header}`;
+});
+Object.entries(legacyPrefix).forEach(([key, value]) => {
+  Headers[key] = `X-Presto-${value}`;
+  TrinoHeaders[key] = `X-Trino-${value}`;
+});
+common.forEach((header) => {
+  Headers[transform(header)] = header;
+  TrinoHeaders[transform(header)] = header;
+});

--- a/lib/presto-client/headers.js
+++ b/lib/presto-client/headers.js
@@ -5,7 +5,7 @@ var TrinoHeaders = exports.TrinoHeaders = {};
 // with the key being the value uppercased and dashes replaced
 // with underscores, e.g. `Max-Size` becomes
 // `{ MAX_SIZE: 'X-Presto-Max-Size' }` on Headers object.
-const commonPrefix = [
+const commonSuffix = [
   'User',
   'Source',
   'Catalog',
@@ -18,7 +18,7 @@ const commonPrefix = [
   'Session',
   'Prepared-Statement',
 ];
-const legacyPrefix = {
+const legacySuffix = {
   'PREPARE': 'Prepared-Statement',
 };
 const common = [
@@ -26,18 +26,18 @@ const common = [
   'Authorization',
 ];
 
-const transform = (key) => {
+const transformToHeaderKeyName = (key) => {
   return key.replace('-', '_').toUpperCase();
 }
 commonPrefix.forEach((header) => {
-  Headers[transform(header)] = `X-Presto-${header}`;
-  TrinoHeaders[transform(header)] = `X-Trino-${header}`;
+  Headers[transformToHeaderKeyName(header)] = `X-Presto-${header}`;
+  TrinoHeaders[transformToHeaderKeyName(header)] = `X-Trino-${header}`;
 });
 Object.entries(legacyPrefix).forEach(([key, value]) => {
   Headers[key] = `X-Presto-${value}`;
   TrinoHeaders[key] = `X-Trino-${value}`;
 });
 common.forEach((header) => {
-  Headers[transform(header)] = header;
-  TrinoHeaders[transform(header)] = header;
+  Headers[transformToHeaderKeyName(header)] = header;
+  TrinoHeaders[transformToHeaderKeyName(header)] = header;
 });

--- a/lib/presto-client/headers.js
+++ b/lib/presto-client/headers.js
@@ -29,11 +29,11 @@ const common = [
 const transformToHeaderKeyName = (key) => {
   return key.replace('-', '_').toUpperCase();
 }
-commonPrefix.forEach((header) => {
+commonSuffix.forEach((header) => {
   Headers[transformToHeaderKeyName(header)] = `X-Presto-${header}`;
   TrinoHeaders[transformToHeaderKeyName(header)] = `X-Trino-${header}`;
 });
-Object.entries(legacyPrefix).forEach(([key, value]) => {
+Object.entries(legacySuffix).forEach(([key, value]) => {
   Headers[key] = `X-Presto-${value}`;
   TrinoHeaders[key] = `X-Trino-${value}`;
 });

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -222,7 +222,7 @@ Client.prototype.statementResource = function(opts) {
         header[client.headers.SCHEMA] = opts.schema || this.schema;
     }
     if (opts.prepares) {
-        header[client.headers.PREPARE] = opts.prepares.map((s, index) => 'query' + index + '=' + encodeURIComponent(s)).join(',');
+        header[client.headers.PREPARED_STATEMENT] = opts.prepares.map((s, index) => 'query' + index + '=' + encodeURIComponent(s)).join(',');
     }
 
     if (opts.session)


### PR DESCRIPTION
PR modifies the `headers.js` file so that the header objects are generated from shared array of values, so that adding a new header is only done once, vs twice, to avoid duplication and potential mispellings and such. I also rewrote the overall object to be a regular object instead of a function with additional properties, as the latter struck me as a bit odd / unnecessary vs just using a regular object.

This is a prep PR for adding additional header values (e.g. `language`, `role`) that the adapter currently does not support.