### PR TITLE
Fix cancelling queries

### DIFF
--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -130,8 +130,12 @@ Client.prototype.request = function(opts, callback) {
         res.on('end', function(){
             var data = response_data;
             var error = null;
-            // Only a 200 response code should be considered successful
-            if (response_code === 200) {
+            // A DELETE request to cancel a query should return 204 No Content, while
+            // all other API requests should return 200 OK with a JSON body.
+            if (opts.method === 'DELETE' && response_code === 204) {
+                data = null;
+            }
+            else if (response_code === 200) {
                 try {
                     if (data[0] !== '{' && data[0] !== '[') {
                         throw new Error();
@@ -191,13 +195,15 @@ Client.prototype.query = function(query_id, callback) {
 
 Client.prototype.kill = function(query_id, callback) {
     this.request({ method: 'DELETE', path: '/v1/query/' + query_id }, function(error, code, data){
-        if (error || code !== 204) {
-            var message = "query kill api returns error" + (data && data.length > 0 ? ":" + data : "");
-            callback({message: message, error: error, code: code});
+        if (!callback) {
             return;
         }
-        if (callback)
-            callback(null);
+        var ret = null;
+        if (error) {
+            var message = "query kill api returns error" + (data && data.length > 0 ? ":" + data : "");
+            ret = {message: message, error: error, code: code};
+        }
+        callback(ret);
     });
 };
 
@@ -347,7 +353,7 @@ Client.prototype.statementResource = function(opts) {
         if (!first_request && cancel_checker && cancel_checker()) {
             clear_timeout();
             client.request({ method: 'DELETE', path: uri_obj }, function(error, code, data){
-                if (error || code !== 204) {
+                if (error) {
                     error_callback({message: "query fetch canceled, but Presto query cancel may fail", error: error, code: code});
                 } else {
                     error_callback({message: "query fetch canceled by operation"});


### PR DESCRIPTION
PR fixes a bug introduced in #74, where the logic was changed such that anything except a 200 response was considered an error. However, when cancelling a query, a 204 is returned, and that would cause the callback passed to `.kill` to have an error object, though the query itself was still properly cancelled. I've included tests for the two paths wherein a user may have a query be cancelled.

I was not able to reproduce the error reported in #75, and the tests use relatively latest versions of presto/trino, so I"m not sure why they were seeing a 404 error.

This also fixes a bug where if you did not pass a callback to `kill` method, then would hit an undefined error, but only if an error was returned from the request. If no error was returned, then things would work fine. Now, if no callback is provided, then the error (or not) is silently swallowed, otherwise passed back to the user.