### PR TITLE
chore: update Buffer.from usage for compatibility

### DIFF
--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -42,7 +42,7 @@ var Client = exports.Client = function(args){
     if (args.custom_auth) {
         this.authorization = args.custom_auth;
     } else if (args.basic_auth) {
-        this.authorization = 'Basic ' + new Buffer.from(args.basic_auth.user + ':' + args.basic_auth.password).toString('base64');
+        this.authorization = 'Basic ' + Buffer.from(args.basic_auth.user + ':' + args.basic_auth.password).toString('base64');
     }
 
     this.protocol = 'http:';

--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -42,7 +42,7 @@ var Client = exports.Client = function(args){
     if (args.custom_auth) {
         this.authorization = args.custom_auth;
     } else if (args.basic_auth) {
-        this.authorization = 'Basic ' + new Buffer(args.basic_auth.user + ':' + args.basic_auth.password).toString('base64');
+        this.authorization = 'Basic ' + new Buffer.from(args.basic_auth.user + ':' + args.basic_auth.password).toString('base64');
     }
 
     this.protocol = 'http:';


### PR DESCRIPTION
The code was updated to resolve a deprecation issue with the `Buffer` constructor in Node.js. The error encountered was:

```
TypeError: Cannot read properties of null (reading '0')
    at isInsideNodeModules (node:internal/util:508:17)
    at showFlaggedDeprecation (node:buffer:178:8)
    at new Buffer (node:buffer:266:3)
    ...
```

This error occurs due to the use of the deprecated `new Buffer()` constructor, which is no longer recommended. Instead, the `Buffer.from()` method should be used for creating buffers from strings.


**Explanation:**

- The `new Buffer()` constructor has been deprecated because of potential security and usability issues.
- The `Buffer.from()` method is the preferred way to create a new buffer from a string. It provides better safety and clarity.

By making this change, the code is updated to be compatible with the latest Node.js standards, eliminating the deprecation warning and potential future issues related to the `Buffer` constructor.

