### PR TITLE
Add option to override client auth header

### DIFF
--- a/lib/presto-client/index.js
+++ b/lib/presto-client/index.js
@@ -64,7 +64,7 @@ var Client = exports.Client = function(args){
     }
 };
 
-Client.prototype.request = function(opts, callback) {
+Client.prototype.request = function(opts, callback, authorization) {
     var client = this;
     var contentBody = null;
 
@@ -102,8 +102,9 @@ Client.prototype.request = function(opts, callback) {
 
     opts.headers[client.headers.USER_AGENT] = this.userAgent;
 
-    if (client.authorization)
-        opts.headers[client.headers.AUTHORIZATION] = this.authorization;
+    var authToUse = authorization || client.authorization;
+    if (authToUse)
+        opts.headers[client.headers.AUTHORIZATION] = authToUse;
 
     if (opts.body)
         contentBody = opts.body;
@@ -239,6 +240,10 @@ Client.prototype.statementResource = function(opts) {
     if (opts.timezone)
         header[client.headers.TIME_ZONE] = opts.timezone;
 
+    if (opts.authorization) {
+        header[client.headers.AUTHORIZATION] = opts.authorization
+    }
+
 
     var fetch_info = opts.info || false;
 
@@ -358,7 +363,7 @@ Client.prototype.statementResource = function(opts) {
                 } else {
                     error_callback({message: "query fetch canceled by operation"});
                 }
-            });
+            }, opts.authorization);
             return;
         }
         current_req = client.request(uri_obj, function(error, code, response){
@@ -446,12 +451,12 @@ Client.prototype.statementResource = function(opts) {
             if (fetch_info && response.infoUri) {
                 client.request(response.infoUri, function(error, code, response){
                     success_callback(null, finishedStats, response);
-                });
+                }, opts.authorization);
             }
             else {
                 success_callback(null, finishedStats);
             }
-        });
+        }, opts.authorization);
     };
     fetch({ method: 'POST', path: '/v1/statement', headers: header, body: opts.query, user: opts.user });
 };


### PR DESCRIPTION
Adds an option to override the `Authorization` header per query.

I have Open Policy Agent adding additional filters to the queries that execute on Trino based on permissions of the user, so need to be able to set the `Authorization` header per query.

I tried creating a new client per query but ran into thread pool exhaustion.